### PR TITLE
Add PTD activation checkpointing API

### DIFF
--- a/metaseq/modules/checkpoint_activations.py
+++ b/metaseq/modules/checkpoint_activations.py
@@ -3,30 +3,44 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import os
 
 def checkpoint_wrapper(module, *args, **kwargs):
-    try:
-        from metaseq.modules.checkpoint_activation_wrapper.checkpoint_activations import (
-            checkpoint_wrapper as _checkpoint_wrapper,
-        )
-    except ImportError:
-        raise ImportError(
-            "Cannot find fairscale.nn.misc.checkpoint_activations. "
-            "Please install fairscale with: pip install fairscale"
-        )
-
-    module = _checkpoint_wrapper(module, *args, **kwargs)
-
-    if hasattr(module, "extra_repr"):
-        orig_extra_repr = module.extra_repr
+    if os.environ.get("USE_PTD_AC", "False") == "True":
+        try:
+            from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
+                checkpoint_wrapper as ptd_checkpoint_wrapper,
+                apply_activation_checkpointing_wrapper,
+            )
+            #module = apply_activation_checkpointing_wrapper(module, checkpoint_wrapper_fn=ptd_checkpoint_wrapper)
+            module = ptd_checkpoint_wrapper(module)
+        except ImportError:
+            raise ImportError(
+                "Cannot find  torch.distributed.algorithms._checkpoint.checkpoint_wrapper."
+            )
     else:
-        orig_extra_repr = None
+        try:
+            from metaseq.modules.checkpoint_activation_wrapper.checkpoint_activations import (
+                checkpoint_wrapper as _checkpoint_wrapper,
+            )
 
-    def extra_repr():
-        return (
-            f"[checkpointed] {orig_extra_repr()}" if orig_extra_repr is not None else ""
-        )
+            module = _checkpoint_wrapper(module, *args, **kwargs)
 
-    module.extra_repr = extra_repr
+            if hasattr(module, "extra_repr"):
+                orig_extra_repr = module.extra_repr
+            else:
+                orig_extra_repr = None
+
+            def extra_repr():
+                return (
+                    f"[Metaseq Built-in checkpointed] {orig_extra_repr()}" if orig_extra_repr is not None else ""
+                )
+
+            module.extra_repr = extra_repr
+        except ImportError:
+            raise ImportError(
+                "Cannot find fairscale.nn.misc.checkpoint_activations. "
+                "Please install fairscale with: pip install fairscale"
+            )
 
     return module


### PR DESCRIPTION
**Patch Description**
Added PTD activation checkpointing logic into Metaseq, it's turned off by default and can be turn on with `USE_PTD_AC`. Currently it's failing with kwargs runtime error so need follow up here to make it e2e working. Here are the gaps we found so far: 
1) kward argument 
2) save non-tensor output, 
3) distribute_activation_checkpointing (not needed if TP is used) 
4) patch_batchnorm. 
5) Megatron RNG state.

**Testing steps**
Describe how you tested your changes

<!--

Considerations before submitting:

- [ ] Was this discussed/approved via a Github issue?
- [ ] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/master/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?
-->
